### PR TITLE
Add async orchestrator with placeholder components

### DIFF
--- a/chains.py
+++ b/chains.py
@@ -1,0 +1,43 @@
+"""Placeholder chain connection management for MEV The OG."""
+
+from dataclasses import dataclass
+import asyncio
+import logging
+
+
+@dataclass
+class ChainConfig:
+    """Simple configuration for a blockchain connection."""
+    name: str
+    rpc_url: str
+
+
+class ChainConnection:
+    """Represents a connection to a single blockchain."""
+
+    def __init__(self, config: ChainConfig) -> None:
+        self.config = config
+        self.connected = False
+
+    async def connect(self) -> None:
+        """Simulate establishing a connection."""
+        logging.info("Connecting to %s at %s", self.config.name, self.config.rpc_url)
+        await asyncio.sleep(0.1)
+        self.connected = True
+        logging.info("Connected to %s", self.config.name)
+
+    async def close(self) -> None:
+        """Simulate closing the connection."""
+        logging.info("Disconnecting from %s", self.config.name)
+        await asyncio.sleep(0.1)
+        self.connected = False
+        logging.info("Disconnected from %s", self.config.name)
+
+
+def load_chains():
+    """Load and initialize available chain connections."""
+    configs = [
+        ChainConfig("ethereum", "http://localhost:8545"),
+        ChainConfig("bsc", "http://localhost:8546"),
+    ]
+    return {cfg.name: ChainConnection(cfg) for cfg in configs}

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+
+from chains import load_chains
+from signal_generator import SignalGenerator
+from risk_manager import RiskManager
+from sandwich_bot import SandwichBot
+
+
+class Orchestrator:
+    """Main orchestration layer coordinating bots across multiple chains."""
+
+    def __init__(self) -> None:
+        # Load chain connections from chains.py
+        self.chains = load_chains()
+        self.signal_generators = {}
+        self.risk_managers = {}
+        self.sandwich_bots = {}
+        self.tasks = []
+
+        # Initialize core components for each chain
+        for name, chain in self.chains.items():
+            self.signal_generators[name] = SignalGenerator(chain)
+            self.risk_managers[name] = RiskManager(chain)
+            self.sandwich_bots[name] = SandwichBot(chain)
+
+    async def start(self) -> None:
+        """Start connections and background tasks."""
+        logging.info("Starting orchestrator...")
+        # Connect to each chain before launching worker tasks
+        await asyncio.gather(*(chain.connect() for chain in self.chains.values()))
+
+        for name in self.chains:
+            bot = self.sandwich_bots[name]
+            # Task to monitor mempool for this chain
+            self.tasks.append(asyncio.create_task(bot.monitor_mempool()))
+            # Task to fetch signals and execute strategies
+            self.tasks.append(asyncio.create_task(self._signal_loop(name)))
+
+        logging.info("Orchestrator started")
+
+    async def stop(self) -> None:
+        """Cancel background tasks and close connections."""
+        logging.info("Stopping orchestrator...")
+
+        for task in self.tasks:
+            task.cancel()
+        await asyncio.gather(*self.tasks, return_exceptions=True)
+
+        await asyncio.gather(*(chain.close() for chain in self.chains.values()))
+        logging.info("Orchestrator stopped")
+
+    async def _signal_loop(self, name: str) -> None:
+        """Continuously fetch signals and execute approved strategies."""
+        generator = self.signal_generators[name]
+        risk = self.risk_managers[name]
+        bot = self.sandwich_bots[name]
+
+        while True:
+            # Retrieve actionable signals for this chain
+            signals = await generator.fetch_signals()
+            for signal in signals:
+                # Check risk before dispatching execution
+                if risk.approve(signal):
+                    await bot.execute(signal)
+            await asyncio.sleep(0)  # yield control to other tasks
+
+
+async def main() -> None:
+    """Entry point for running the orchestrator."""
+    logging.basicConfig(level=logging.INFO)
+    orchestrator = Orchestrator()
+    await orchestrator.start()
+    try:
+        # Run indefinitely until cancelled or interrupted
+        while True:
+            await asyncio.sleep(3600)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        pass
+    finally:
+        await orchestrator.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/risk_manager.py
+++ b/risk_manager.py
@@ -1,0 +1,15 @@
+"""Placeholder risk management logic."""
+
+import logging
+
+
+class RiskManager:
+    """Evaluates risk for potential trades."""
+
+    def __init__(self, chain) -> None:
+        self.chain = chain
+
+    def approve(self, signal) -> bool:
+        """Return True if the trade associated with ``signal`` is allowed."""
+        logging.debug("Risk check for %s: %s", self.chain.config.name, signal)
+        return True

--- a/sandwich_bot.py
+++ b/sandwich_bot.py
@@ -1,0 +1,26 @@
+"""Placeholder sandwich bot implementation."""
+
+import asyncio
+import logging
+
+
+class SandwichBot:
+    """Executes sandwich strategies on a given chain."""
+
+    def __init__(self, chain) -> None:
+        self.chain = chain
+
+    async def monitor_mempool(self) -> None:
+        """Continuously monitor the chain's mempool."""
+        logging.info("Monitoring mempool on %s", self.chain.config.name)
+        while True:
+            await asyncio.sleep(1)
+
+    async def execute(self, signal) -> None:
+        """Execute a sandwich strategy derived from ``signal``."""
+        logging.info(
+            "Executing sandwich strategy on %s for signal %s",
+            self.chain.config.name,
+            signal,
+        )
+        await asyncio.sleep(0.1)

--- a/signal_generator.py
+++ b/signal_generator.py
@@ -1,0 +1,17 @@
+"""Placeholder signal generation logic."""
+
+import asyncio
+import logging
+
+
+class SignalGenerator:
+    """Generates trading signals for a specific chain."""
+
+    def __init__(self, chain) -> None:
+        self.chain = chain
+
+    async def fetch_signals(self):
+        """Fetch actionable signals from external sources."""
+        logging.debug("Fetching signals for %s", self.chain.config.name)
+        await asyncio.sleep(0.1)
+        return []


### PR DESCRIPTION
## Summary
- add an `orchestrator.py` module using asyncio to coordinate bots on multiple chains
- stub out `chains.py`, `signal_generator.py`, `risk_manager.py`, and `sandwich_bot.py`

## Testing
- `pytest -q` *(fails: command not found)*